### PR TITLE
Fix various stylistic issues

### DIFF
--- a/core/encoding.lisp
+++ b/core/encoding.lisp
@@ -378,7 +378,7 @@ in `util/strencoding.h`."
               (decf bits to-bits)
               (funcall output-fn (logand (ash acc (- bits)) maxv))))
     (if padp
-        (when (not (zerop bits))
+        (unless (zerop bits)
           (funcall output-fn (logand (ash acc (- to-bits bits)) maxv)))
         (when (or (>= bits from-bits)
                   (not (zerop (logand (ash acc (- to-bits bits)) maxv))))
@@ -411,11 +411,11 @@ in `util/strencoding.h`."
                (setf upper t)))
     :finally (and lower upper (error 'bech32-mixed-case-characters-error)))
   (let ((pos (position #\1 string :test #'char= :from-end t)))
-    (when (not pos)
+    (unless pos
       (error 'bech32-no-separator-character-error))
     (when (zerop pos)
       (error 'bech32-no-hrp-error))
-    (when (not (< pos (- (length string) 6)))
+    (unless (< pos (- (length string) 6))
       (error 'bech32-no-checksum-error))
     (let* ((values-length (- (length string) pos 1))
            (values (make-byte-array values-length))

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -377,7 +377,7 @@ script structure:
     <20-byte witness-program>"
   (and
    (segwit-p script-pubkey)
-   (eq 0 (command-number (aref (script-commands script-pubkey) 0)))
+   (= 0 (command-number (aref (script-commands script-pubkey) 0)))
    (= 20 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun p2wsh-p (script-pubkey)
@@ -387,7 +387,7 @@ script structure:
     <32-byte witness-program>"
   (and
    (segwit-p script-pubkey)
-   (eq 0 (command-number (aref (script-commands script-pubkey) 0)))
+   (= 0 (command-number (aref (script-commands script-pubkey) 0)))
    (= 32 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun p2tr-p (script-pubkey)
@@ -397,7 +397,7 @@ sturcture:
    <32-byte witness-program>"
   (and
    (segwit-p script-pubkey)
-   (eq 1 (command-number (aref (script-commands script-pubkey) 0)))
+   (= 1 (command-number (aref (script-commands script-pubkey) 0)))
    (= 32 (length (command-payload (aref (script-commands script-pubkey) 1))))))
 
 (defun script-standard-p (script-pubkey &key network)

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -78,7 +78,7 @@ for `OP_PUSHDATA*` commands."
 
 (defun command-payload-length (command)
   (when (command-pushdata-p command)
-    (car (cdr command))))
+    (second command)))
 
 (defun command-number (command)
   "If a given script command is a simple integer data push command,

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -617,7 +617,7 @@ value will write the trace to that stream).")
               (write-bytes witness-script-data stream witness-script-length)))
            (witness-program
             (command-payload (aref (script-commands script-pubkey) 1))))
-      (when (not (equalp (sha256 witness-script-data) witness-program))
+      (unless (equalp (sha256 witness-script-data) witness-program)
         (error "P2WSH error: hash mismatch."))
       (ironclad:with-octet-input-stream (stream witness-script-bytes)
         (execute-script (parse 'script stream) :state state)))))
@@ -832,7 +832,7 @@ alt stack."
 (define-opcode op_ifdup 115 #x73 (state)
   "If the top stack value is not 0, duplicate it."
   (when (>= (length (@stack state)) 1)
-    (when (not (zerop (decode-integer (first (@stack state)))))
+    (unless (zerop (decode-integer (first (@stack state))))
       (push (first (@stack state)) (@stack state)))
     t))
 

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -906,8 +906,7 @@ alt stack."
   "The item at the top of the stack is copied and inserted before the
 second-to-top item."
   (when (>= (length (@stack state)) 2)
-    (setf (cddr (@stack state))
-          (cons (first (@stack state)) (cddr (@stack state))))
+    (push (first (@stack state)) (cddr (@stack state)))
     t))
 
 (define-opcode op_2drop 109 #x6d (state)

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -149,13 +149,14 @@ otherwise."
            :for i :below num-bytes
            :for byte :from 0 :by 8
            :do (vector-push (ldb (byte 8 byte) ainteger) bytes)
-           :finally (if (zerop (logand (aref bytes (1- i)) #x80))
-                        (when negative-p
-                          (setf (aref bytes (1- i))
-                                (logior (aref bytes (1- i)) #x80)))
-                        (if negative-p
-                            (vector-push #x80 bytes)
-                            (vector-push #x00 bytes))))
+           :finally (cond ((zerop (logand (aref bytes (1- i)) #x80))
+                           (when negative-p
+                             (setf (aref bytes (1- i))
+                                   (logior (aref bytes (1- i)) #x80))))
+                          (negative-p
+                           (vector-push #x80 bytes))
+                          (t
+                           (vector-push #x00 bytes))))
         bytes)
       #()))
 
@@ -230,13 +231,14 @@ otherwise."
   (flet ((print-command  (c)
            (let ((opcode (command-opcode c))
                  (payload (command-payload c)))
-             (if (command-simple-p c)
-                 (format nil "~{~:@(~a~)~^/~}" (opcode opcode))
-                 (if *print-script-as-assembly*
-                     (format nil "~a" (hex-encode payload))
-                     (format nil "~{~:@(~a~)~^/~} ~a"
-                             (opcode opcode)
-                             (hex-encode payload)))))))
+             (cond ((command-simple-p c)
+                    (format nil "~{~:@(~a~)~^/~}" (opcode opcode)))
+                   (*print-script-as-assembly*
+                    (format nil "~a" (hex-encode payload)))
+                   (t
+                    (format nil "~{~:@(~a~)~^/~} ~a"
+                            (opcode opcode)
+                            (hex-encode payload)))))))
     (let ((commands (map 'list #'print-command (script-commands script))))
       (if *print-script-as-assembly*
           (format stream "~{~a~^ ~}" commands)

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -197,7 +197,7 @@ otherwise."
                       (payload-size (min expected-payload-size (- script-len i 1)))
                       (payload (read-bytes script-stream payload-size)))
                  (push (make-command opcode :payload payload) commands)
-                 (incf i (+ 1 payload-size))))
+                 (incf i (1+ payload-size))))
               ((<= (opcode :op_pushdata1) opcode (opcode :op_pushdata4))
                (let* ((expected-length-size (cond ((= opcode (opcode :op_pushdata1)) 1)
                                                ((= opcode (opcode :op_pushdata2)) 2)
@@ -217,7 +217,7 @@ otherwise."
                                payload-size :n-bits (* 8 payload-length-size) :big-endian nil)))
                        (push (make-command opcode :payload payload :payload-length length) commands)
                        (incf i payload-size)))
-                 (incf i (+ 1 payload-length-size))))
+                 (incf i (1+ payload-length-size))))
               (t
                (push opcode commands)
                (incf i)))))
@@ -315,7 +315,7 @@ pattern:
     (and (>= length 3)
          (command-number (aref commands 0))
          (command-number (aref commands (- length 2)))
-         (= (command-opcode (aref commands (- length 1))) (opcode :op_checkmultisig))
+         (= (command-opcode (aref commands (1- length))) (opcode :op_checkmultisig))
          (every #'command-payload (subseq commands 1 (- length 2))))))
 
 (defun null-data-p (script-pubkey)
@@ -609,7 +609,7 @@ value will write the trace to that stream).")
     (execute-script (apply #'script witness-stack) :state state)
     ;; Verify that SHA256(<witness-script>) is equal to
     ;; <witness-program>, decode and execute witness script.
-    (let* ((witness-script-data (aref witness (- witness-length 1)))
+    (let* ((witness-script-data (aref witness (1- witness-length)))
            (witness-script-length (length witness-script-data))
            (witness-script-bytes
             (ironclad:with-octet-output-stream (stream)

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -45,7 +45,7 @@
 `OP_PUSH*` and `OP_PUSHDATA*` commands, argument `payload-length` - only
 for `OP_PUSHDATA*` commands."
   (cond ((and payload payload-length)
-         (cons op (cons payload-length payload)))
+         (list* op payload-length payload))
         (payload
          (cons op payload))
         (t

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -369,40 +369,40 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
                     (when (= pos inputlen) (%fail))
                     (setf lenbyte (aref input pos))
                     (incf pos)
-                    (if (not (= 0 (logand lenbyte #x80)))
-                        (progn
-                          (decf lenbyte #x80)
-                          (when (> lenbyte (- inputlen pos)) (%fail))
-                          (loop
+                    (cond ((not (= 0 (logand lenbyte #x80)))
+                           (decf lenbyte #x80)
+                           (when (> lenbyte (- inputlen pos)) (%fail))
+                           (loop
                              :while (and (> lenbyte 0) (= 0 (aref input pos)))
                              :do
-                               (incf pos)
-                               (decf lenbyte))
-                          (when (>= lenbyte 4) (%fail))
-                          (setf ,clen 0)
-                          (loop
+                                (incf pos)
+                                (decf lenbyte))
+                           (when (>= lenbyte 4) (%fail))
+                           (setf ,clen 0)
+                           (loop
                              :while (> lenbyte 0)
                              :do
-                               (setf ,clen (+ (ash ,clen 8) (aref input pos)))
-                               (incf pos)
-                               (decf lenbyte)))
-                        (setf ,clen lenbyte))
+                                (setf ,clen (+ (ash ,clen 8) (aref input pos)))
+                                (incf pos)
+                                (decf lenbyte)))
+                          (t
+                           (setf ,clen lenbyte)))
                     (when (> ,clen (- inputlen pos)) (%fail))
                     (setf ,cpos pos)))
                (%skip-zeroes (cpos clen)
                  `(loop
-                     :while (and (> ,clen 0) (= 0 (aref input ,cpos)))
-                     :do
+                    :while (and (> ,clen 0) (= 0 (aref input ,cpos)))
+                    :do
                        (decf ,clen)
                        (incf ,cpos)))
                (%copy (cpos clen offset)
                  `(if (> ,clen 32)
                       (setf overflow t)
                       (loop
-                         :for i :below ,clen
-                         :do (setf
-                              (aref tmpsig (+ (- ,offset ,clen) i))
-                              (aref input (+ ,cpos i)))))))
+                        :for i :below ,clen
+                        :do (setf
+                             (aref tmpsig (+ (- ,offset ,clen) i))
+                             (aref input (+ ,cpos i)))))))
       ;; Sequence tag byte.
       (setf pos 0)
       (when (or (= pos inputlen) (/= (aref input pos) #x30))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -412,7 +412,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
       (when (= pos inputlen) (%fail))
       (setf lenbyte (aref input pos))
       (incf pos)
-      (when (not (= 0 (logand lenbyte #x80)))
+      (unless (= 0 (logand lenbyte #x80))
         (decf lenbyte #x80)
         (when (> lenbyte (- inputlen pos)) (%fail))
         (incf pos lenbyte))
@@ -434,7 +434,7 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
       ;; Copy S value.
       (%copy spos slen 64)
       ;; Parse fixed signature.
-      (when (not overflow)
+      (unless overflow
         (setf overflow (not (setf sig (ecdsa-signature-parse-compact tmpsig)))))
       (when overflow
         ;; Overwrite the result again with a correctly-parsed but

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -776,13 +776,13 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
   (ec-pubkey-serialize (key-bytes key)))
 
 (defun parse-signature (bytes &key (type :relaxed))
-  (let* ((bytes (ecase type
-                  (:compact
-                   (ecdsa-signature-parse-compact bytes))
-                  (:der
-                   (ecdsa-signature-parse-der bytes))
-                  (:relaxed
-                   (ecdsa-signature-parse-der-lax bytes)))))
+  (let ((bytes (ecase type
+                 (:compact
+                  (ecdsa-signature-parse-compact bytes))
+                 (:der
+                  (ecdsa-signature-parse-der bytes))
+                 (:relaxed
+                  (ecdsa-signature-parse-der-lax bytes)))))
     (%make-signature :bytes bytes)))
 
 (defun serialize-signature (signature &key (type :der))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -113,7 +113,7 @@
   (data :unsigned-char :count 64))
 
 ;; All flags' lower 8 bits indicate what they're for. Do not use directly.
-(defconstant +secp256k1-flags-type-mask+        (- (ash 1 8) 1))
+(defconstant +secp256k1-flags-type-mask+        (1- (ash 1 8)))
 (defconstant +secp256k1-flags-type-context+     (ash 1 0))
 (defconstant +secp256k1-flags-type-compression+ (ash 1 1))
 ;; The higher bits contain the actual data. Do not use directly.


### PR DESCRIPTION
These changes are mostly fixing (smaller) stylistical issues.
Exception is [Fix EQL on numbers](https://github.com/rodentrabies/bp/commit/2c2c3c454521599c520bc00fe3e84907447f0d34):
Using `=` to compare numbers is better, since `=` signals a _type-error_ if supplied non-number, while `EQL` does not.