### PR TITLE
meta: introduce dot-separated package nicknames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ as consistent as possible.
 
 ## BP 0.0.4
 
+- **BREAKING**: package nicknames `bpcore`, `bpcrypto`, `bprpc` and
+  `bpnet` were removed in favor of the new `.`-seraparted nicknames
+  that should be preferred in all cases.
+
 - New representation format for `OP_PUSHDATA*` script commands now
   includes a byte sequence representation of the length of the payload
   to ensure `(serialize (parse ...))` produces the same byte sequence
@@ -20,7 +24,7 @@ as consistent as possible.
 ## BP 0.0.3
 
 - The RPC-based chain supplier `bp:node-connection` was renamed to
-  `bprpc:node-rpc-connection` for clarity. It is still possible to use
+  `bp.rpc:node-rpc-connection` for clarity. It is still possible to use
   the `bp:node-connection` name, but it will issue a warning and will
   be removed in one of the next `0.0.*` releases.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 Seibart Nedor <rodentrabies@protonmail.com>
+Copyright (c) 2019-2022 Seibart Nedor <rodentrabies@protonmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/core/all.lisp
+++ b/core/all.lisp
@@ -1,5 +1,6 @@
-(uiop:define-package :bp/core/all (:use :cl)
-  (:nicknames :bp)
+(uiop:define-package :bp/core/all
+  (:nicknames :bp :bp.core)
+  (:use :cl)
   (:use-reexport
    :bp/core/encoding
    :bp/core/transaction

--- a/core/block.lisp
+++ b/core/block.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/block (:use :cl)
+(uiop:define-package :bp/core/block
+  (:nicknames :bp.core.block)
+  (:use :cl)
   (:use :bp/core/encoding
         :bp/core/transaction
         :bp/crypto/hash)
@@ -18,7 +20,7 @@
    #:block-transactions
    #:block-transaction))
 
-(in-package :bp/core/block)
+(in-package :bp.core.block)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/chain.lisp
+++ b/core/chain.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/chain (:use :cl)
+(uiop:define-package :bp/core/chain
+  (:nicknames :bp.core.chain)
+  (:use :cl)
   (:use :bp/core/block
         :bp/core/transaction
         :bp/core/encoding)
@@ -27,7 +29,7 @@
    #:unknown-transaction-error
    #:unknown-transaction-id))
 
-(in-package :bp/core/chain)
+(in-package :bp.core.chain)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/consensus.lisp
+++ b/core/consensus.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/consensus (:use :cl)
+(uiop:define-package :bp/core/consensus
+  (:nicknames :bp.core.consensus)
+  (:use :cl)
   (:use :bp/core/encoding
         :bp/core/chain
         :bp/core/merkletree
@@ -13,7 +15,7 @@
    #:validation-context
    #:make-validation-context))
 
-(in-package :bp/core/consensus)
+(in-package :bp.core.consensus)
 
 
 ;;; The definitions in this file contain Bitcoin consensus rules. The

--- a/core/encoding.lisp
+++ b/core/encoding.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/encoding (:use :cl :ironclad)
+(uiop:define-package :bp/core/encoding
+  (:nicknames :bp.core.encoding)
+  (:use :cl :ironclad)
   (:use :bp/crypto/hash)
   (:export
    ;; Serialization API:
@@ -39,7 +41,7 @@
    #:bech32-mixed-case-characters-error
    #:bech32-no-separator-character-error))
 
-(in-package :bp/core/encoding)
+(in-package :bp.core.encoding)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/merkletree.lisp
+++ b/core/merkletree.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/merkletree (:use :cl)
+(uiop:define-package :bp/core/merkletree
+  (:nicknames :bp.core.merkletree)
+  (:use :cl)
   (:use :bp/core/encoding
         :bp/core/transaction
         :bp/crypto/hash)
@@ -7,7 +9,7 @@
    #:merkle-tree-node
    #:merkle-tree-node-hash))
 
-(in-package :bp/core/merkletree)
+(in-package :bp.core.merkletree)
 
 (defstruct merkle-tree-node
   hash

--- a/core/parameters.lisp
+++ b/core/parameters.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/parameters (:use :cl)
+(uiop:define-package :bp/core/parameters
+  (:nicknames :bp.core.parameters)
+  (:use :cl)
   (:export
    ;; Constants:
    #:+initial-block-reward+
@@ -12,7 +14,7 @@
    ;; BP-specific parameters:
    #:*bp-version*))
 
-(in-package :bp/core/parameters)
+(in-package :bp.core.parameters)
 
 
 

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/script (:use :cl)
+(uiop:define-package :bp/core/script
+  (:nicknames :bp.core.script)
+  (:use :cl)
   (:use
    :bp/core/encoding
    :bp/core/parameters
@@ -17,7 +19,7 @@
    ;; #:*print-script-as-assembly* ;; not exported yet
    #:*trace-script-execution*))
 
-(in-package :bp/core/script)
+(in-package :bp.core.script)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/transaction.lisp
+++ b/core/transaction.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/core/transaction (:use :cl)
+(uiop:define-package :bp/core/transaction
+  (:nicknames :bp.core.transaction)
+  (:use :cl)
   (:use
    :bp/core/encoding
    :bp/core/script
@@ -31,7 +33,7 @@
    #:witness
    #:witness-items))
 
-(in-package :bp/core/transaction)
+(in-package :bp.core.transaction)
 
 (defstruct tx
   version

--- a/crypto/all.lisp
+++ b/crypto/all.lisp
@@ -1,5 +1,6 @@
-(uiop:define-package :bp/crypto/all (:use :cl)
-  (:nicknames :bpcrypto)
+(uiop:define-package :bp/crypto/all
+  (:nicknames :bp.crypto)
+  (:use :cl)
   (:use-reexport
    :bp/crypto/random
    :bp/crypto/hash

--- a/crypto/hash.lisp
+++ b/crypto/hash.lisp
@@ -1,5 +1,6 @@
 (uiop:define-package :bp/crypto/hash
-    (:use :cl :ironclad)
+  (:nicknames :bp.crypto.hash)
+  (:use :cl :ironclad)
   (:export
    #:sha1
    #:ripemd160
@@ -7,7 +8,7 @@
    #:hash256
    #:hash160))
 
-(in-package :bp/crypto/hash)
+(in-package :bp.crypto.hash)
 
 (defun sha1 (bytes)
   (let ((digester (ironclad:make-digest 'ironclad:sha1)))

--- a/crypto/random.lisp
+++ b/crypto/random.lisp
@@ -1,8 +1,10 @@
-(uiop:define-package :bp/crypto/random (:use :cl)
+(uiop:define-package :bp/crypto/random
+  (:nicknames :bp.crypto.random)
+  (:use :cl)
   (:export
    #:random-bytes))
 
-(in-package :bp/crypto/random)
+(in-package :bp.crypto.random)
 
 (defun random-bytes (size)
   (let ((buffer (make-array size :element-type '(unsigned-byte 8))))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -1,6 +1,7 @@
-(uiop:define-package :bp/crypto/secp256k1 (:use :cl :cffi :ironclad)
+(uiop:define-package :bp/crypto/secp256k1
+  (:nicknames :bp.crypto.secp256k1 :secp256k1)
+  (:use :cl :cffi :ironclad)
   (:use :bp/crypto/random)
-  (:nicknames :secp256k1)
   (:shadow
    ;; Ironclad's symbols
    #:make-signature
@@ -39,7 +40,7 @@
    #:parse-signature
    #:serialize-signature))
 
-(in-package :bp/crypto/secp256k1)
+(in-package :bp.crypto.secp256k1)
 
 ;;; This file contains manual translation of the secp256k1.h file from
 ;;; libsecp256k1/include directory as well as wrappers around API functions that

--- a/net/address.lisp
+++ b/net/address.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/net/address (:use :cl)
+(uiop:define-package :bp/net/address
+  (:nicknames :bp.net.address)
+  (:use :cl)
   (:use :bp/core/encoding)
   (:import-from :usocket)
   (:export
@@ -8,7 +10,7 @@
    #:address-from-bytes
    #:random-peer-address))
 
-(in-package :bp/net/address)
+(in-package :bp.net.address)
 
 ;;; Address management and peer-discovery utilities.
 

--- a/net/all.lisp
+++ b/net/all.lisp
@@ -1,4 +1,5 @@
-(uiop:define-package :bp/net/all (:nicknames :bpnet)
+(uiop:define-package :bp/net/all
+  (:nicknames :bp.net)
   (:use-reexport
    :bp/net/parameters
    :bp/net/address

--- a/net/message.lisp
+++ b/net/message.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/net/message (:use :cl)
+(uiop:define-package :bp/net/message
+  (:nicknames :bp.net.message)
+  (:use :cl)
   (:use :bp/core/all
         :bp/net/address)
   (:import-from :ironclad)
@@ -32,7 +34,7 @@
    #:message-type-from-command))
 
 
-(in-package :bp/net/message)
+(in-package :bp.net.message)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/net/node.lisp
+++ b/net/node.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/net/node (:use :cl)
+(uiop:define-package :bp/net/node
+  (:nicknames :bp.net.node)
+  (:use :cl)
   (:use :bp/core/all
         :bp/crypto/all
         :bp/net/parameters
@@ -21,7 +23,7 @@
    #:node-host
    #:node-port))
 
-(in-package :bp/net/node)
+(in-package :bp.net.node)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/net/parameters.lisp
+++ b/net/parameters.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/net/parameters (:use :cl)
+(uiop:define-package :bp/net/parameters
+  (:nicknames :bp.net.parameters)
+  (:use :cl)
   (:use :bp/core/all)
   (:export
    ;; Network constants:
@@ -22,7 +24,7 @@
    #:*user-agent*))
 
 
-(in-package :bp/net/parameters)
+(in-package :bp.net.parameters)
 
 ;;;-----------------------------------------------------------------------------
 ;;; Network contants

--- a/rpc/all.lisp
+++ b/rpc/all.lisp
@@ -1,5 +1,6 @@
-(uiop:define-package :bp/rpc/all (:use :cl)
-  (:nicknames :bprpc)
+(uiop:define-package :bp/rpc/all
+  (:nicknames :bp.rpc)
+  (:use :cl)
   (:import-from :aserve)
   (:import-from :jsown)
   (:use :bp/core/all)
@@ -14,7 +15,7 @@
    #:getrawtransaction
    #:getchaintxstats))
 
-(in-package :bp/rpc/all)
+(in-package :bp.rpc)
 
 
 ;;;-----------------------------------------------------------------------------
@@ -147,11 +148,11 @@ RPC server."))
 
 ;;; Redefine BP:NODE-CONNECTION here for backward compatibility.
 ;;; These will be removed in one of the upcoming 0.0.* releases.
-(in-package :bp/core/all)
+(in-package :bp.core)
 
-(defclass node-connection (bprpc:node-rpc-connection) ())
+(defclass node-connection (bp.rpc:node-rpc-connection) ())
 
 (defmethod initialize-instance :after ((object node-connection) &rest args)
   (declare (ignore args))
   (warn "BP:NODE-CONNECTION has been deprecated in favor of ~
-         BPRPC:NODE-RPC-CONNECTION."))
+         BP.RPC:NODE-RPC-CONNECTION."))

--- a/tests/all.lisp
+++ b/tests/all.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/tests/all (:use :cl)
+(uiop:define-package :bp/tests/all
+  (:nicknames :bp.tests)
+  (:use :cl)
   (:use
    :bp/tests/encoding
    :bp/tests/block

--- a/tests/block.lisp
+++ b/tests/block.lisp
@@ -1,8 +1,10 @@
-(uiop:define-package :bp/tests/block (:use :cl :fiveam)
+(uiop:define-package :bp/tests/block
+  (:nicknames :bp.tests.block)
+  (:use :cl :fiveam)
   (:use :bp/core/all
         :bp/tests/data))
 
-(in-package :bp/tests/block)
+(in-package :bp.tests.block)
 
 (def-suite block-tests
     :description "Tests for block parsing, serialization and

--- a/tests/data.lisp
+++ b/tests/data.lisp
@@ -1,4 +1,6 @@
-(uiop:define-package :bp/tests/data (:use :cl)
+(uiop:define-package :bp/tests/data
+  (:nicknames :bp.tests.data)
+  (:use :cl)
   (:use :bp/core/all)
   (:export
    #:test-chain-supplier
@@ -8,7 +10,7 @@
    #:*test-chain-transactions*
    #:*all-test-transactions*))
 
-(in-package :bp/tests/data)
+(in-package :bp.tests.data)
 
 ;;; Storage for test chain supplier.
 (defvar *test-chain-block-hashes* (make-hash-table)

--- a/tests/encoding.lisp
+++ b/tests/encoding.lisp
@@ -1,9 +1,11 @@
-(uiop:define-package :bp/tests/encoding (:use :cl :fiveam)
+(uiop:define-package :bp/tests/encoding
+  (:nicknames :bp.tests.encoding)
+  (:use :cl :fiveam)
   (:use :bp/core/all)
   (:import-from :bp/crypto/random
                 #:random-bytes))
 
-(in-package :bp/tests/encoding)
+(in-package :bp.tests.encoding)
 
 (def-suite encoding-tests
   :description "Tests for various encoding formats used by Bitcoin
@@ -82,7 +84,7 @@ isomorphism."
     (values bytes hrp encoding)))
 
 (defun segwit-version-opcode (number)
-  ;; TODO: maybe make this a more general utility in BP/CORE/SCRIPT.
+  ;; TODO: maybe make this a more general utility in `bp.core.script'.
   (if (<= 0 number 16)
       (intern (format nil "~a_~a" 'op number) :keyword)
       (error "Segwit version must be in between 0 and 16.")))

--- a/tests/script.lisp
+++ b/tests/script.lisp
@@ -1,8 +1,10 @@
-(uiop:define-package :bp/tests/script (:use :cl :fiveam)
+(uiop:define-package :bp/tests/script
+  (:nicknames :bp.tests.script)
+  (:use :cl :fiveam)
   (:use :bp/core/all
         :bp/tests/data))
 
-(in-package :bp/tests/script)
+(in-package :bp.tests.script)
 
 (def-suite script-tests
     :description "Various script tests.")
@@ -10,7 +12,7 @@
 (in-suite script-tests)
 
 (test standard-script-types
-  :description "Test that `bp/core/script:script-standard-p' function recognizes
+  :description "Test that `bp.core.script:script-standard-p' function recognizes
 types of standard scripts."
   (with-chain-supplier (test-chain-supplier)
     (loop

--- a/tests/transaction.lisp
+++ b/tests/transaction.lisp
@@ -1,10 +1,12 @@
-(uiop:define-package :bp/tests/transaction (:use :cl :fiveam)
+(uiop:define-package :bp/tests/transaction
+  (:nicknames :bp.tests.transaction)
+  (:use :cl :fiveam)
   (:use :bp/core/all
         :bp/tests/data)
   (:import-from :bp/core/block
                 #:block-header-version))
 
-(in-package :bp/tests/transaction)
+(in-package :bp.tests.transaction)
 
 (def-suite transaction-tests
     :description "Tests for transaction parsing, serialization and


### PR DESCRIPTION
This is a first step towards eliminating `/`-separated package names which are harder to read.