### PR TITLE
fix type pubkey serialize

### DIFF
--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -1805,8 +1805,8 @@ arbitrary subset of format violations (see Bitcoin's pubkey.cpp)."
 (defun parse-pubkey (bytes)
   (%make-pubkey :bytes (ec-pubkey-parse bytes)))
 
-(defun serialize-pubkey (key)
-  (ec-pubkey-serialize (key-bytes key)))
+(defun serialize-pubkey (pubkey &key compressed)
+  (ec-pubkey-serialize (pubkey-bytes pubkey) :compressed compressed))
 
 (defun parse-signature (bytes &key (type :relaxed))
   (let* ((bytes (ecase type


### PR DESCRIPTION
To serialize a pubkey the function needs the pubkey-bytes, the function as written now took a private key.
This fixes the function to request the correct struct of a pubkey by using the correct slot reader.

Additionally include the compressed key argument.