### PR TITLE
crypto: expose secp256k1 `combine-pubkeys`

### DIFF
--- a/tests/all.lisp
+++ b/tests/all.lisp
@@ -1,6 +1,7 @@
 (uiop:define-package :bp/tests/all (:use :cl)
   (:use
    :bp/tests/encoding
+   :bp/tests/crypto
    :bp/tests/block
    :bp/tests/transaction
    :bp/tests/script))

--- a/tests/crypto.lisp
+++ b/tests/crypto.lisp
@@ -1,0 +1,32 @@
+(uiop:define-package :bp/tests/crypto (:use :cl :fiveam)
+  (:use :bp/crypto/all))
+
+(in-package :bp/tests/crypto)
+
+(def-suite crypto-tests
+  :description "Tests for crypto tools.")
+
+(in-suite crypto-tests)
+
+(defun scale-key (scalar seckey)
+  (bp/crypto/secp256k1::%make-key
+   :bytes
+   (ironclad:integer-to-octets
+    (mod
+     (* scalar (ironclad:octets-to-integer (bp/crypto/secp256k1::key-bytes seckey)))
+     #xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141)
+    :n-bits #.(* 8 32))))
+
+(test pubkey-combination
+  (for-all ((scalar (gen-integer :min 1 :max 10)))
+    (let* ((seckey (make-key))
+           (pubkey (make-pubkey seckey))
+           (combined pubkey)
+           (scaled-sec (scale-key scalar seckey))
+           (scaled-pub (make-pubkey scaled-sec)))
+      (dotimes (_ (1- scalar))
+        (setq combined (combine-pubkeys combined pubkey)))
+      (is (equalp scaled-pub combined))
+      ;; using reduce vector
+      (is (equalp scaled-pub
+                  (apply #'combine-pubkeys (make-list scalar :initial-element pubkey)))))))


### PR DESCRIPTION
This will require some feedback rounds as I'm not to familiar with cffi.

I want to expose the combine function to add public keys.  The function supports and array of public keys, yet I could only figure out how to do it pair-wise. The function I expose does support multiple keys, yet that happens over pairwise reduction at the lisp level.

I include a test, that compares the secret key multiplication to the repeated addition of the public key.