### PR TITLE
meta: use dots instead of slashes in qualified package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # `bp` API changes
 
-Here is a list of API changes for each version of `bp` to help users to
-identify potential incompatibilities.
+Here is a list of API changes for each version of `bp` to help users
+to identify potential incompatibilities.
 
-Changes that are marked with **BREAKING** are breaking the
+Changes that are marked with **\[BREAKING\]** are breaking the
 compatibility with the older versions by removing/replacing one or
 more exported symbols or changing the behaviour of one or more
 exported functions. Generally these will become very rare with
 versions 0.1 and onward, but until 0.1 are bound to happen to make API
 as consistent as possible.
+
+## BP 0.0.5
+
+- **\[BREAKING\]** All slash-separated package names were replaced
+  with dot-separated ones (e.g. `bp/crypto/secp256k1` became
+  `bp.crypto.secp256k1`). The old package names are still available as
+  aliases, but will be removed in the future. Package names
+  `bp.crypto`, `bp.net` and `bp.rpc` should be used instead of aliases
+  `bpcrypto`, `bpnet` and `bprpc`, which will be removed in the future
+  as well.
 
 ## BP 0.0.4
 
@@ -17,18 +27,18 @@ as consistent as possible.
   to ensure `(serialize (parse ...))` produces the same byte sequence
   even for scripts with unexpected ends.
 
-- Functions `bp/crypto/secp256k1:context-create-{none,sign,verify}`
+- Functions `bp.crypto.secp256k1:context-create-{none,sign,verify}`
   for context initialization no longer exist and their functionality
-  has been replaced with `bp/crypto/secp256k1::context-create` and
-  `bp/crypto/secp256k1::context-randomize` which are unexported.
+  has been replaced with `bp.crypto.secp256k1::context-create` and
+  `bp.crypto.secp256k1::context-randomize` which are unexported.
 
 ## BP 0.0.3
 
 - The RPC-based chain supplier `bp:node-connection` was renamed to
-  `bprpc:node-rpc-connection` for clarity. It is still possible to use
-  the `bp:node-connection` name, but it will issue a warning and will
-  be removed in one of the next `0.0.*` releases.
+  `bp.rpc:node-rpc-connection` for clarity. It is still possible to
+  use the `bp:node-connection` name, but it will issue a warning and
+  will be removed in one of the next `0.0.*` releases.
 
-- **BREAKING**: functions `bp:to-hex` and `bp:from-hex` were renamed
-  to `bp:hex-encode` and `bp:hex-decode` respectively for consistency
-  with other encoding functions.
+- **\[BREAKING\]** Functions `bp:to-hex` and `bp:from-hex` were
+  renamed to `bp:hex-encode` and `bp:hex-decode` respectively for
+  consistency with other encoding functions.

--- a/bp.asd
+++ b/bp.asd
@@ -7,7 +7,6 @@
   :author "rodentrabies <rodentrabies@protonmail.com>"
   :license "MIT"
   :class :package-inferred-system
-  :pathname #P"./"
   :in-order-to ((test-op (test-op "bp/tests")))
   ;; Components:
   :depends-on ("bp/core/all"
@@ -21,15 +20,44 @@
                "ironclad"
                "usocket"))
 
+(register-system-packages "bp/core/all" :bp.core)
+(register-system-packages "bp/core/block" :bp.core.block)
+(register-system-packages "bp/core/chain" :bp.core.chain)
+(register-system-packages "bp/core/consensus" :bp.core.consensus)
+(register-system-packages "bp/core/encoding" :bp.core.encoding)
+(register-system-packages "bp/core/merkletree" :bp.core.merkletree)
+(register-system-packages "bp/core/parameters" :bp.core.parameters)
+(register-system-packages "bp/core/script" :bp.core.script)
+(register-system-packages "bp/core/transaction" :bp.core.transaction)
+
+(register-system-packages "bp/crypto/all" :bp.crypto)
+(register-system-packages "bp/crypto/hash" :bp.crypto.hash)
+(register-system-packages "bp/crypto/random" :bp.crypto.random)
+(register-system-packages "bp/crypto/secp256k1" :bp.crypto.secp256k1)
+
+(register-system-packages "bp/net/all" :bp.net)
+(register-system-packages "bp/net/address" :bp.net.address)
+(register-system-packages "bp/net/message" :bp.net.message)
+(register-system-packages "bp/net/node" :bp.net.node)
+(register-system-packages "bp/net/parameters" :bp.net.parameters)
+
 
 
 (defsystem "bp/tests"
     :description "Test system for BP"
   :class :package-inferred-system
-  :pathname #P "./tests"
+  :pathname "tests/"
   :perform (test-op (o c) (uiop:symbol-call :fiveam :run-all-tests))
   ;; Components:
   :depends-on ("bp"
                "bp/tests/all")
   ;; External dependencies:
   :depends-on ("fiveam"))
+
+(register-system-packages "bp/tests/all" :bp.tests)
+(register-system-packages "bp/tests/block" :bp.tests.block)
+(register-system-packages "bp/tests/crypto" :bp.tests.crypto)
+(register-system-packages "bp/tests/data" :bp.tests.data)
+(register-system-packages "bp/tests/encoding" :bp.tests.encoding)
+(register-system-packages "bp/tests/script" :bp.tests.script)
+(register-system-packages "bp/tests/transaction" :bp.tests.transaction)

--- a/core/all.lisp
+++ b/core/all.lisp
@@ -1,16 +1,16 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/all (:use :cl)
-  (:nicknames :bp)
+(uiop:define-package :bp.core (:nicknames :bp :bp/core/all)
+  (:use :cl)
   (:use-reexport
-   :bp/core/encoding
-   :bp/core/transaction
-   :bp/core/script
-   :bp/core/block
-   :bp/core/chain
-   :bp/core/merkletree
-   :bp/core/parameters
-   :bp/core/consensus)
+   :bp.core.block
+   :bp.core.chain
+   :bp.core.consensus
+   :bp.core.encoding
+   :bp.core.merkletree
+   :bp.core.parameters
+   :bp.core.script
+   :bp.core.transaction)
   ;; For backward compatibility purposes (see rpc/all.lisp).
   (:export #:node-connection))

--- a/core/block.lisp
+++ b/core/block.lisp
@@ -1,10 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/block (:use :cl)
-  (:use :bp/core/encoding
-        :bp/core/transaction
-        :bp/crypto/hash)
+(uiop:define-package :bp.core.block (:nicknames :bp/core/block)
+  (:use :cl)
+  (:use :bp.core.encoding
+        :bp.core.transaction
+        :bp.crypto.hash)
   (:export
    ;; Block header API:
    #:block-header
@@ -21,7 +22,7 @@
    #:block-transactions
    #:block-transaction))
 
-(in-package :bp/core/block)
+(in-package :bp.core.block)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/chain.lisp
+++ b/core/chain.lisp
@@ -1,10 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/chain (:use :cl)
-  (:use :bp/core/block
-        :bp/core/transaction
-        :bp/core/encoding)
+(uiop:define-package :bp.core.chain (:nicknames :bp/core/chain)
+  (:use :cl)
+  (:use :bp.core.block
+        :bp.core.transaction
+        :bp.core.encoding)
   (:export
    ;; Chain supplier API:
    #:*chain-supplier*
@@ -30,7 +31,7 @@
    #:unknown-transaction-error
    #:unknown-transaction-id))
 
-(in-package :bp/core/chain)
+(in-package :bp.core.chain)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/consensus.lisp
+++ b/core/consensus.lisp
@@ -1,22 +1,23 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/consensus (:use :cl)
-  (:use :bp/core/encoding
-        :bp/core/chain
-        :bp/core/merkletree
-        :bp/core/block
-        :bp/core/transaction
-        :bp/core/script
-        :bp/core/parameters
-        :bp/crypto/hash)
+(uiop:define-package :bp.core.consensus (:nicknames :bp/core/consensus)
+  (:use :cl)
+  (:use :bp.core.encoding
+        :bp.core.chain
+        :bp.core.merkletree
+        :bp.core.block
+        :bp.core.transaction
+        :bp.core.script
+        :bp.core.parameters
+        :bp.crypto.hash)
   (:export
    #:validate
    #:validp
    #:validation-context
    #:make-validation-context))
 
-(in-package :bp/core/consensus)
+(in-package :bp.core.consensus)
 
 
 ;;; The definitions in this file contain Bitcoin consensus rules. The

--- a/core/encoding.lisp
+++ b/core/encoding.lisp
@@ -1,8 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/encoding (:use :cl :ironclad)
-  (:use :bp/crypto/hash)
+(uiop:define-package :bp.core.encoding (:nicknames :bp/core/encoding)
+  (:use :cl :ironclad)
+  (:use :bp.crypto.hash)
   (:export
    ;; Serialization API:
    #:serialize
@@ -42,7 +43,7 @@
    #:bech32-mixed-case-characters-error
    #:bech32-no-separator-character-error))
 
-(in-package :bp/core/encoding)
+(in-package :bp.core.encoding)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/merkletree.lisp
+++ b/core/merkletree.lisp
@@ -1,16 +1,17 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/merkletree (:use :cl)
-  (:use :bp/core/encoding
-        :bp/core/transaction
-        :bp/crypto/hash)
+(uiop:define-package :bp.core.merkletree (:nicknames :bp/core/merkletree)
+  (:use :cl)
+  (:use :bp.core.encoding
+        :bp.core.transaction
+        :bp.crypto.hash)
   (:export
    #:build-merkle-tree
    #:merkle-tree-node
    #:merkle-tree-node-hash))
 
-(in-package :bp/core/merkletree)
+(in-package :bp.core.merkletree)
 
 (defstruct merkle-tree-node
   hash

--- a/core/parameters.lisp
+++ b/core/parameters.lisp
@@ -1,7 +1,8 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/parameters (:use :cl)
+(uiop:define-package :bp.core.parameters (:nicknames :bp/core/parameters)
+  (:use :cl)
   (:export
    ;; Constants:
    #:+initial-block-reward+
@@ -15,7 +16,7 @@
    ;; BP-specific parameters:
    #:*bp-version*))
 
-(in-package :bp/core/parameters)
+(in-package :bp.core.parameters)
 
 
 

--- a/core/script.lisp
+++ b/core/script.lisp
@@ -1,12 +1,13 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/script (:use :cl)
+(uiop:define-package :bp.core.script (:nicknames :bp/core/script)
+  (:use :cl)
   (:use
-   :bp/core/encoding
-   :bp/core/parameters
-   :bp/crypto/hash
-   :bp/crypto/secp256k1)
+   :bp.core.encoding
+   :bp.core.parameters
+   :bp.crypto.hash
+   :bp.crypto.secp256k1)
   (:export
    #:script
    #:decode-integer
@@ -20,7 +21,7 @@
    ;; #:*print-script-as-assembly* ;; not exported yet
    #:*trace-script-execution*))
 
-(in-package :bp/core/script)
+(in-package :bp.core.script)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/core/transaction.lisp
+++ b/core/transaction.lisp
@@ -1,11 +1,12 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/core/transaction (:use :cl)
+(uiop:define-package :bp.core.transaction (:nicknames :bp/core/transaction)
+  (:use :cl)
   (:use
-   :bp/core/encoding
-   :bp/core/script
-   :bp/crypto/hash)
+   :bp.core.encoding
+   :bp.core.script
+   :bp.crypto.hash)
   (:export
    ;; Transaction API:
    #:tx
@@ -34,7 +35,7 @@
    #:witness
    #:witness-items))
 
-(in-package :bp/core/transaction)
+(in-package :bp.core.transaction)
 
 (defstruct tx
   version

--- a/crypto/all.lisp
+++ b/crypto/all.lisp
@@ -1,9 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/crypto/all (:use :cl)
-  (:nicknames :bpcrypto)
+(uiop:define-package :bp.crypto (:nicknames :bpcrypto :bp/crypto/all)
+  (:use :cl)
   (:use-reexport
-   :bp/crypto/random
-   :bp/crypto/hash
-   :bp/crypto/secp256k1))
+   :bp.crypto.hash
+   :bp.crypto.random
+   :bp.crypto.secp256k1))

--- a/crypto/hash.lisp
+++ b/crypto/hash.lisp
@@ -1,8 +1,8 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/crypto/hash
-    (:use :cl :ironclad)
+(uiop:define-package :bp.crypto.hash (:nicknames :bp/crypto/hash)
+  (:use :cl :ironclad)
   (:export
    #:sha1
    #:ripemd160
@@ -10,7 +10,7 @@
    #:hash256
    #:hash160))
 
-(in-package :bp/crypto/hash)
+(in-package :bp.crypto.hash)
 
 (defun sha1 (bytes)
   (let ((digester (ironclad:make-digest 'ironclad:sha1)))

--- a/crypto/random.lisp
+++ b/crypto/random.lisp
@@ -1,11 +1,12 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/crypto/random (:use :cl)
+(uiop:define-package :bp.crypto.random (:nicknames :bp/crypto/random)
+  (:use :cl)
   (:export
    #:random-bytes))
 
-(in-package :bp/crypto/random)
+(in-package :bp.crypto.random)
 
 (defun random-bytes (size)
   (let ((buffer (make-array size :element-type '(unsigned-byte 8))))

--- a/crypto/secp256k1.lisp
+++ b/crypto/secp256k1.lisp
@@ -1,9 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/crypto/secp256k1 (:use :cl :cffi :ironclad)
-  (:use :bp/crypto/random)
-  (:nicknames :secp256k1)
+(uiop:define-package :bp.crypto.secp256k1 (:nicknames :secp256k1 :bp/crypto/secp256k1)
+  (:use :cl :cffi :ironclad)
+  (:use :bp.crypto.random)
   (:shadow
    ;; Ironclad's symbols
    #:make-signature
@@ -39,7 +39,7 @@
    #:parse-signature
    #:serialize-signature))
 
-(in-package :bp/crypto/secp256k1)
+(in-package :bp.crypto.secp256k1)
 
 ;;;-----------------------------------------------------------------------------
 ;;; libsecp256k1

--- a/net/address.lisp
+++ b/net/address.lisp
@@ -1,8 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/net/address (:use :cl)
-  (:use :bp/core/encoding)
+(uiop:define-package :bp.net.address (:nicknames :bp/net/address)
+  (:use :cl)
+  (:use :bp.core.encoding)
   (:import-from :usocket)
   (:export
    ;; Address utilities:
@@ -11,7 +12,7 @@
    #:address-from-bytes
    #:random-peer-address))
 
-(in-package :bp/net/address)
+(in-package :bp.net.address)
 
 ;;; Address management and peer-discovery utilities.
 

--- a/net/all.lisp
+++ b/net/all.lisp
@@ -1,9 +1,10 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/net/all (:nicknames :bpnet)
+(uiop:define-package :bp.net (:nicknames :bpnet :bp/net/all)
+  (:use :cl)
   (:use-reexport
-   :bp/net/parameters
-   :bp/net/address
-   :bp/net/message
-   :bp/net/node))
+   :bp.net.address
+   :bp.net.message
+   :bp.net.node
+   :bp.net.parameters))

--- a/net/message.lisp
+++ b/net/message.lisp
@@ -1,9 +1,10 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/net/message (:use :cl)
-  (:use :bp/core/all
-        :bp/net/address)
+(uiop:define-package :bp.net.message (:nicknames :bp/net/message)
+  (:use :cl)
+  (:use :bp.core
+        :bp.net.address)
   (:import-from :ironclad)
   (:import-from :usocket)
   ;; Messages and their field accessors are automatically exported by
@@ -35,7 +36,7 @@
    #:message-type-from-command))
 
 
-(in-package :bp/net/message)
+(in-package :bp.net.message)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/net/node.lisp
+++ b/net/node.lisp
@@ -1,12 +1,13 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/net/node (:use :cl)
-  (:use :bp/core/all
-        :bp/crypto/all
-        :bp/net/parameters
-        :bp/net/address
-        :bp/net/message)
+(uiop:define-package :bp.net.node (:nicknames :bp/net/node)
+  (:use :cl)
+  (:use :bp.core
+        :bp.crypto
+        :bp.net.parameters
+        :bp.net.address
+        :bp.net.message)
   (:import-from :ironclad)
   (:import-from :usocket)
   (:export
@@ -24,7 +25,7 @@
    #:node-host
    #:node-port))
 
-(in-package :bp/net/node)
+(in-package :bp.net.node)
 
 
 ;;;-----------------------------------------------------------------------------

--- a/net/parameters.lisp
+++ b/net/parameters.lisp
@@ -1,8 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/net/parameters (:use :cl)
-  (:use :bp/core/all)
+(uiop:define-package :bp.net.parameters (:nicknames :bp/net/parameters)
+  (:use :cl)
+  (:use :bp.core)
   (:export
    ;; Network constants:
    #:+network-magic+
@@ -25,7 +26,7 @@
    #:*user-agent*))
 
 
-(in-package :bp/net/parameters)
+(in-package :bp.net.parameters)
 
 ;;;-----------------------------------------------------------------------------
 ;;; Network contants

--- a/rpc/all.lisp
+++ b/rpc/all.lisp
@@ -1,11 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/rpc/all (:use :cl)
-  (:nicknames :bprpc)
+(uiop:define-package :bp.rpc (:nicknames :bprpc :bp/rpc/all)
+  (:use :cl)
   (:import-from :aserve)
   (:import-from :jsown)
-  (:use :bp/core/all)
+  (:use :bp.core)
   (:export
    ;; Classes and conditions:
    #:node-connection ;; will be removed soon
@@ -17,7 +17,7 @@
    #:getrawtransaction
    #:getchaintxstats))
 
-(in-package :bp/rpc/all)
+(in-package :bp.rpc)
 
 
 ;;;-----------------------------------------------------------------------------
@@ -150,11 +150,11 @@ RPC server."))
 
 ;;; Redefine BP:NODE-CONNECTION here for backward compatibility.
 ;;; These will be removed in one of the upcoming 0.0.* releases.
-(in-package :bp/core/all)
+(in-package :bp.core)
 
-(defclass node-connection (bprpc:node-rpc-connection) ())
+(defclass node-connection (bp.rpc:node-rpc-connection) ())
 
 (defmethod initialize-instance :after ((object node-connection) &rest args)
   (declare (ignore args))
   (warn "BP:NODE-CONNECTION has been deprecated in favor of ~
-         BPRPC:NODE-RPC-CONNECTION."))
+         BP.RPC:NODE-RPC-CONNECTION."))

--- a/tests/all.lisp
+++ b/tests/all.lisp
@@ -1,10 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/all (:use :cl)
+(uiop:define-package :bp.tests (:nicknames :bp/tests/all)
+  (:use :cl)
   (:use
-   :bp/tests/encoding
-   :bp/tests/crypto
-   :bp/tests/block
-   :bp/tests/transaction
-   :bp/tests/script))
+   :bp.tests.encoding
+   :bp.tests.crypto
+   :bp.tests.block
+   :bp.tests.transaction
+   :bp.tests.script))

--- a/tests/block.lisp
+++ b/tests/block.lisp
@@ -1,11 +1,12 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/block (:use :cl :fiveam)
-  (:use :bp/core/all
-        :bp/tests/data))
+(uiop:define-package :bp.tests.block
+  (:use :cl :fiveam)
+  (:use :bp.core
+        :bp.tests.data))
 
-(in-package :bp/tests/block)
+(in-package :bp.tests.block)
 
 (def-suite block-tests
     :description "Tests for block parsing, serialization and

--- a/tests/crypto.lisp
+++ b/tests/crypto.lisp
@@ -1,10 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/crypto (:use :cl :fiveam)
-  (:use :bp/crypto/all))
+(uiop:define-package :bp.tests.crypto
+  (:use :cl :fiveam)
+  (:use :bp.crypto))
 
-(in-package :bp/tests/crypto)
+(in-package :bp.tests.crypto)
 
 (def-suite crypto-tests
   :description "Tests for crypto tools.")
@@ -12,11 +13,11 @@
 (in-suite crypto-tests)
 
 (defun scale-key (scalar seckey)
-  (bp/crypto/secp256k1::%make-key
+  (bp.crypto.secp256k1::%make-key
    :bytes
    (ironclad:integer-to-octets
     (mod
-     (* scalar (ironclad:octets-to-integer (bp/crypto/secp256k1::key-bytes seckey)))
+     (* scalar (ironclad:octets-to-integer (bp.crypto.secp256k1::key-bytes seckey)))
      #xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141)
     :n-bits #.(* 8 32))))
 

--- a/tests/data.lisp
+++ b/tests/data.lisp
@@ -1,8 +1,9 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/data (:use :cl)
-  (:use :bp/core/all)
+(uiop:define-package :bp.tests.data
+  (:use :cl)
+  (:use :bp.core)
   (:export
    #:test-chain-supplier
    #:*test-chain-block-hashes*
@@ -11,7 +12,7 @@
    #:*test-chain-transactions*
    #:*all-test-transactions*))
 
-(in-package :bp/tests/data)
+(in-package :bp.tests.data)
 
 ;;; Storage for test chain supplier.
 (defvar *test-chain-block-hashes* (make-hash-table)

--- a/tests/encoding.lisp
+++ b/tests/encoding.lisp
@@ -1,10 +1,11 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/encoding (:use :cl :fiveam)
-  (:use :bp/core/all))
+(uiop:define-package :bp.tests.encoding
+  (:use :cl :fiveam)
+  (:use :bp.core))
 
-(in-package :bp/tests/encoding)
+(in-package :bp.tests.encoding)
 
 (def-suite encoding-tests
   :description "Tests for various encoding formats used by Bitcoin
@@ -73,7 +74,7 @@ isomorphism."
     (values bytes hrp encoding)))
 
 (defun segwit-version-opcode (number)
-  ;; TODO: maybe make this a more general utility in BP/CORE/SCRIPT.
+  ;; TODO: maybe make this a more general utility in BP.CORE.SCRIPT.
   (if (<= 0 number 16)
       (intern (format nil "~a_~a" 'op number) :keyword)
       (error "Segwit version must be in between 0 and 16.")))

--- a/tests/script.lisp
+++ b/tests/script.lisp
@@ -1,11 +1,12 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/script (:use :cl :fiveam)
-  (:use :bp/core/all
-        :bp/tests/data))
+(uiop:define-package :bp.tests.script
+  (:use :cl :fiveam)
+  (:use :bp.core
+        :bp.tests.data))
 
-(in-package :bp/tests/script)
+(in-package :bp.tests.script)
 
 (def-suite script-tests
     :description "Various script tests.")
@@ -13,7 +14,7 @@
 (in-suite script-tests)
 
 (test standard-script-types
-  :description "Test that `bp/core/script:script-standard-p' function recognizes
+  :description "Test that `bp.core.script:script-standard-p' function recognizes
 types of standard scripts."
   (with-chain-supplier (test-chain-supplier)
     (loop

--- a/tests/transaction.lisp
+++ b/tests/transaction.lisp
@@ -1,13 +1,14 @@
 ;;; Copyright (c) 2019-2023 BP Developers & Contributors
 ;;; See the accompanying file LICENSE for the full license governing this code.
 
-(uiop:define-package :bp/tests/transaction (:use :cl :fiveam)
-  (:use :bp/core/all
-        :bp/tests/data)
-  (:import-from :bp/core/block
+(uiop:define-package :bp.tests.transaction
+  (:use :cl :fiveam)
+  (:use :bp.core
+        :bp.tests.data)
+  (:import-from :bp.core.block
                 #:block-header-version))
 
-(in-package :bp/tests/transaction)
+(in-package :bp.tests.transaction)
 
 (def-suite transaction-tests
     :description "Tests for transaction parsing, serialization and


### PR DESCRIPTION
This PR replaces all slash-separated package names with dot-separated ones, e.g. `bp/crypto/random` becomes `bp.crypto.random`. The old package names still exist as aliases but will be removed in the future.